### PR TITLE
Make compatible with Django 1.7+

### DIFF
--- a/dajaxice/views.py
+++ b/dajaxice/views.py
@@ -55,6 +55,9 @@ class DajaxiceRequest(View):
                     raise
                 response = dajaxice_config.DAJAXICE_EXCEPTION
 
-            return HttpResponse(response, mimetype="application/x-json")
+            if django.get_version() >= '1.7':
+                return HttpResponse(response, content_type="application/x-json")
+            else:
+                return HttpResponse(response, mimetype="application/x-json")
         else:
             raise FunctionNotCallableError(name)


### PR DESCRIPTION
`mimetype` keyword was removed from HttpResponse in Django 1.7; `content_type` should be used
(see https://docs.djangoproject.com/en/1.7/internals/deprecation/#deprecation-removed-in-1-7)