### PR TITLE
Fix use of django utils importlib in dajaxice

### DIFF
--- a/dajaxice/core/Dajaxice.py
+++ b/dajaxice/core/Dajaxice.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.utils.importlib import import_module
+from importlib import import_module
 
 log = logging.getLogger('dajaxice')
 


### PR DESCRIPTION
Replace django.utils.importlib to importlib because django.utils.importlib is reprecated and created for old version of python and django.

https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib


The standard importlib library works with any django and python versions.